### PR TITLE
pyroscope(p9): internalshim

### DIFF
--- a/.github/workflows/unit-test-on-pull-request.yml
+++ b/.github/workflows/unit-test-on-pull-request.yml
@@ -148,7 +148,7 @@ jobs:
         uses: actions/checkout@v4
       - name: Install dependencies
         run: |
-          sudo apt-get update -y
+          sudo apt-get update -y && sudo apt-get -y install file
           case "${{ matrix.target_arch }}" in
             amd64) sudo apt-get -y install qemu-system-x86;;
             arm64) sudo apt-get -y install qemu-system-arm;;
@@ -169,6 +169,7 @@ jobs:
       - name: Test on kernel ${{ matrix.kernel }}
         run: |
           ls -ltr *.test
+          file *test
           chmod a+rx *.test
           case "${{ matrix.target_arch }}" in
             amd64) export QEMU_ARCH=x86_64;;

--- a/internal/controller/config.go
+++ b/internal/controller/config.go
@@ -44,6 +44,11 @@ type Config struct {
 
 	Reporter reporter.Reporter
 
+	PyroscopeUsername               string
+	PyroscopePasswordFile           string
+	PyroscopeReporterType           string
+	PyroscopeDynamicProfilingPolicy bool
+
 	Fs *flag.FlagSet
 
 	SymbCachePath         string

--- a/pyroscope/internalshim/controller/config.go
+++ b/pyroscope/internalshim/controller/config.go
@@ -1,0 +1,142 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package controller
+
+import (
+	"flag"
+	"fmt"
+	"time"
+
+	"github.com/peterbourgon/ff/v3"
+
+	"go.opentelemetry.io/ebpf-profiler/internal/controller"
+	"go.opentelemetry.io/ebpf-profiler/support"
+	"go.opentelemetry.io/ebpf-profiler/tracer"
+)
+
+const (
+	// Default values for CLI flags
+	defaultArgSamplesPerSecond    = 20
+	defaultArgReporterInterval    = 5.0 * time.Second
+	defaultArgMonitorInterval     = 5.0 * time.Second
+	defaultClockSyncInterval      = 3 * time.Minute
+	defaultProbabilisticThreshold = tracer.ProbabilisticThresholdMax
+	defaultProbabilisticInterval  = 1 * time.Minute
+	defaultArgSendErrorFrames     = false
+	defaultOffCPUThreshold        = 0
+
+	// This is the X in 2^(n + x) where n is the default hardcoded map size value
+	defaultArgMapScaleFactor = 0
+)
+
+// Help strings for command line arguments
+var (
+	noKernelVersionCheckHelp = "Disable checking kernel version for eBPF support. " +
+		"Use at your own risk, to run the agent on older kernels with backported eBPF features."
+	copyrightHelp      = "Show copyright and short license text."
+	collAgentAddrHelp  = "The collection agent address in the format of host:port."
+	verboseModeHelp    = "Enable verbose logging and debugging capabilities."
+	tracersHelp        = "Comma-separated list of interpreter tracers to include."
+	mapScaleFactorHelp = fmt.Sprintf("Scaling factor for eBPF map sizes. "+
+		"Every increase by 1 doubles the map size. Increase if you see eBPF map size errors. "+
+		"Default is %d corresponding to 4GB of executable address space, max is %d.",
+		defaultArgMapScaleFactor, controller.MaxArgMapScaleFactor)
+	disableTLSHelp             = "Disable encryption for data in transit."
+	bpfVerifierLogLevelHelp    = "Log level of the eBPF verifier output (0,1,2). Default is 0."
+	versionHelp                = "Show version."
+	probabilisticThresholdHelp = fmt.Sprintf("If set to a value between 1 and %d will enable "+
+		"probabilistic profiling: "+
+		"every probabilistic-interval a random number between 0 and %d is "+
+		"chosen. If the given probabilistic-threshold is greater than this "+
+		"random number, the agent will collect profiles from this system for "+
+		"the duration of the interval.",
+		tracer.ProbabilisticThresholdMax-1, tracer.ProbabilisticThresholdMax-1)
+	probabilisticIntervalHelp = "Time interval for which probabilistic profiling will be " +
+		"enabled or disabled."
+	pprofHelp             = "Listening address (e.g. localhost:6060) to serve pprof information."
+	samplesPerSecondHelp  = "Set the frequency (in Hz) of stack trace sampling."
+	reporterIntervalHelp  = "Set the reporter's interval in seconds."
+	monitorIntervalHelp   = "Set the monitor interval in seconds."
+	clockSyncIntervalHelp = "Set the sync interval with the realtime clock. " +
+		"If zero, monotonic-realtime clock sync will be performed once, " +
+		"on agent startup, but not periodically."
+	sendErrorFramesHelp = "Send error frames (devfiler only, breaks Kibana)"
+	offCPUThresholdHelp = fmt.Sprintf("The per-mille chance for an off-cpu event being recorded. "+
+		"Valid values are in the range [1..%d], and 0 to disable off-cpu profiling."+
+		"Default is %d.",
+		support.OffCPUThresholdMax, defaultOffCPUThreshold)
+)
+
+// Package-scope variable, so that conditionally compiled other components can refer
+// to the same flagset.
+
+func ParseArgs() (*Config, error) {
+	var args = new(controller.Config)
+
+	fs := flag.NewFlagSet("ebpf-profiler", flag.ExitOnError)
+
+	// Please keep the parameters ordered alphabetically in the source-code.
+	fs.UintVar(&args.BpfVerifierLogLevel, "bpf-log-level", 0, bpfVerifierLogLevelHelp)
+
+	fs.StringVar(&args.CollAgentAddr, "collection-agent", "", collAgentAddrHelp)
+	fs.BoolVar(&args.Copyright, "copyright", false, copyrightHelp)
+
+	fs.BoolVar(&args.DisableTLS, "disable-tls", false, disableTLSHelp)
+
+	fs.UintVar(&args.MapScaleFactor, "map-scale-factor",
+		defaultArgMapScaleFactor, mapScaleFactorHelp)
+
+	fs.DurationVar(&args.MonitorInterval, "monitor-interval", defaultArgMonitorInterval,
+		monitorIntervalHelp)
+
+	fs.DurationVar(&args.ClockSyncInterval, "clock-sync-interval", defaultClockSyncInterval,
+		clockSyncIntervalHelp)
+
+	fs.BoolVar(&args.NoKernelVersionCheck, "no-kernel-version-check", false,
+		noKernelVersionCheckHelp)
+
+	fs.StringVar(&args.PprofAddr, "pprof", "", pprofHelp)
+
+	fs.DurationVar(&args.ProbabilisticInterval, "probabilistic-interval",
+		defaultProbabilisticInterval, probabilisticIntervalHelp)
+	fs.UintVar(&args.ProbabilisticThreshold, "probabilistic-threshold",
+		defaultProbabilisticThreshold, probabilisticThresholdHelp)
+
+	fs.DurationVar(&args.ReporterInterval, "reporter-interval", defaultArgReporterInterval,
+		reporterIntervalHelp)
+
+	fs.IntVar(&args.SamplesPerSecond, "samples-per-second", defaultArgSamplesPerSecond,
+		samplesPerSecondHelp)
+
+	fs.BoolVar(&args.SendErrorFrames, "send-error-frames", defaultArgSendErrorFrames,
+		sendErrorFramesHelp)
+
+	fs.StringVar(&args.Tracers, "t", "all", "Shorthand for -tracers.")
+	fs.StringVar(&args.Tracers, "tracers", "all", tracersHelp)
+
+	fs.BoolVar(&args.VerboseMode, "v", false, "Shorthand for -verbose.")
+	fs.BoolVar(&args.VerboseMode, "verbose", false, verboseModeHelp)
+	fs.BoolVar(&args.Version, "version", false, versionHelp)
+
+	fs.UintVar(&args.OffCPUThreshold, "off-cpu-threshold",
+		defaultOffCPUThreshold, offCPUThresholdHelp)
+
+	RegisterPyroscopeFlags(fs, args)
+
+	fs.Usage = func() {
+		fs.PrintDefaults()
+	}
+
+	args.Fs = fs
+
+	return &Config{args}, ff.Parse(fs, []string{},
+		ff.WithEnvVarPrefix("OTEL_PROFILING_AGENT"),
+		ff.WithConfigFileFlag("config"),
+		ff.WithConfigFileParser(ff.PlainParser),
+		// This will ignore configuration file (only) options that the current HA
+		// does not recognize.
+		ff.WithIgnoreUndefined(true),
+		ff.WithAllowMissingConfigFile(true),
+	)
+}

--- a/pyroscope/internalshim/controller/controller.go
+++ b/pyroscope/internalshim/controller/controller.go
@@ -1,0 +1,29 @@
+package controller
+
+import (
+	"context"
+
+	"go.opentelemetry.io/ebpf-profiler/internal/controller"
+)
+
+type Controller struct {
+	*controller.Controller
+}
+
+func (c *Controller) Start(ctx context.Context) error {
+	return c.Controller.Start(ctx)
+}
+
+type Config struct {
+	*controller.Config
+}
+
+func (cfg *Config) Validate() error {
+	return cfg.Config.Validate()
+}
+
+func New(cfg *Config) *Controller {
+	return &Controller{
+		controller.New(cfg.Config),
+	}
+}

--- a/pyroscope/internalshim/controller/pyroconfig.go
+++ b/pyroscope/internalshim/controller/pyroconfig.go
@@ -15,4 +15,18 @@ func RegisterPyroscopeFlags(fs *flag.FlagSet, args *controller.Config) {
 		"",
 	)
 	fs.StringVar(&args.SymbCachePath, "pyroscope-symb-cache-path", "/tmp/symb-cache", "")
+	fs.StringVar(
+		&args.PyroscopeReporterType,
+		"pyroscope-reporter-type",
+		"pprof",
+		"possible values: otel, pprof",
+	)
+	fs.StringVar(&args.PyroscopeUsername, "pyroscope-username", "", "")
+	fs.StringVar(&args.PyroscopePasswordFile, "pyroscope-password-file", "", "")
+	fs.BoolVar(
+		&args.PyroscopeDynamicProfilingPolicy,
+		"pyroscope-dynamic-profiling-policy",
+		true,
+		"true for sd targets only profiling policy",
+	)
 }

--- a/pyroscope/internalshim/helpers/helpers.go
+++ b/pyroscope/internalshim/helpers/helpers.go
@@ -1,0 +1,13 @@
+package helpers
+
+import (
+	"go.opentelemetry.io/ebpf-profiler/internal/helpers"
+)
+
+func GetKernelVersion() (string, error) {
+	return helpers.GetKernelVersion()
+}
+
+func GetHostnameAndSourceIP(domain string) (hostname, sourceIP string, err error) {
+	return helpers.GetHostnameAndSourceIP(domain)
+}

--- a/support/run-tests.sh
+++ b/support/run-tests.sh
@@ -3,6 +3,7 @@
 # Requires qemu-system-$QEMU_ARCH and bluebox to be installed.
 
 set -eu
+set -x
 set -o pipefail
 
 qemu_arch="${QEMU_ARCH:-x86_64}"


### PR DESCRIPTION
This PR creates a proxy package allowing to use some(controller, helper) internal packages from the outside of this repo (alloy)

These fields are not used in the repo. They are used in alloy: they allow to select reporter type pprof/otel, user/pass for otel reporter, and dynamic profiling policy - profile only targets versus allways on profiling.
```
	PyroscopeUsername               string
	PyroscopePasswordFile           string
	PyroscopeReporterType           string
	PyroscopeDynamicProfilingPolicy bool
```

Unfortunately I had to copy-paste / duplicate config.go