### PR TITLE
Reapply "lidia: dynsym symbols"

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -45,10 +45,12 @@ require (
 )
 
 require (
-	github.com/grafana/pyroscope/lidia v0.0.2-0.20251216080959-a49b562cd2fc
+	github.com/grafana/pyroscope/lidia v0.0.2
 	github.com/prometheus/common v0.55.0
 	github.com/prometheus/prometheus v0.51.2
 )
+
+replace github.com/grafana/pyroscope/lidia => /home/korniltsev/pyroscope/lidia
 
 require (
 	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.4 // indirect

--- a/go.mod
+++ b/go.mod
@@ -50,8 +50,6 @@ require (
 	github.com/prometheus/prometheus v0.51.2
 )
 
-replace github.com/grafana/pyroscope/lidia => /home/korniltsev/pyroscope/lidia
-
 require (
 	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.4 // indirect
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.6 // indirect

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ module go.opentelemetry.io/ebpf-profiler
 // For the OpenTelemetry eBPF Profiler distribution specifically, see
 // https://github.com/open-telemetry/opentelemetry-collector-releases/tree/main/distributions/otelcol-ebpf-profiler
 
-go 1.24.0
+go 1.24.6
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.41.0
@@ -45,7 +45,7 @@ require (
 )
 
 require (
-	github.com/grafana/pyroscope/lidia v0.0.0-20250716102313-506840f4afcd
+	github.com/grafana/pyroscope/lidia v0.0.2-0.20251216080959-a49b562cd2fc
 	github.com/prometheus/common v0.55.0
 	github.com/prometheus/prometheus v0.51.2
 )

--- a/go.sum
+++ b/go.sum
@@ -70,6 +70,8 @@ github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/grafana/pyroscope/lidia v0.0.2 h1:DsZiUjWfB+6w9wKGosEQQTFuDvkay7kUECw3Os7Xno0=
+github.com/grafana/pyroscope/lidia v0.0.2/go.mod h1:4AxmVrn7RJPBStqSw+0erQN2kr+I6MW6LmaawOM8Nlo=
 github.com/grafana/regexp v0.0.0-20221122212121-6b5c0a4cb7fd h1:PpuIBO5P3e9hpqBD0O/HjhShYuM6XE0i/lbE6J94kww=
 github.com/grafana/regexp v0.0.0-20221122212121-6b5c0a4cb7fd/go.mod h1:M5qHK+eWfAv8VR/265dIuEpL3fNfeC21tXXp9itM24A=
 github.com/hashicorp/go-version v1.8.0 h1:KAkNb1HAiZd1ukkxDFGmokVZe1Xy9HG6NUp+bPle2i4=

--- a/go.sum
+++ b/go.sum
@@ -70,8 +70,6 @@ github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
-github.com/grafana/pyroscope/lidia v0.0.2-0.20251216080959-a49b562cd2fc h1:aaY+Oax8VpaoyGZlBq3h+XIT/aTHkZPm2Op4IVRLykY=
-github.com/grafana/pyroscope/lidia v0.0.2-0.20251216080959-a49b562cd2fc/go.mod h1:4AxmVrn7RJPBStqSw+0erQN2kr+I6MW6LmaawOM8Nlo=
 github.com/grafana/regexp v0.0.0-20221122212121-6b5c0a4cb7fd h1:PpuIBO5P3e9hpqBD0O/HjhShYuM6XE0i/lbE6J94kww=
 github.com/grafana/regexp v0.0.0-20221122212121-6b5c0a4cb7fd/go.mod h1:M5qHK+eWfAv8VR/265dIuEpL3fNfeC21tXXp9itM24A=
 github.com/hashicorp/go-version v1.8.0 h1:KAkNb1HAiZd1ukkxDFGmokVZe1Xy9HG6NUp+bPle2i4=

--- a/go.sum
+++ b/go.sum
@@ -70,8 +70,8 @@ github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
-github.com/grafana/pyroscope/lidia v0.0.0-20250716102313-506840f4afcd h1:WextuO1kNdBvFMboocZZREULEJDDr9pMxqsy0e/oni8=
-github.com/grafana/pyroscope/lidia v0.0.0-20250716102313-506840f4afcd/go.mod h1:3f/0/CzhTk1moGlVOp2nJQKCAL+4M5GTnkfDd5hqDIk=
+github.com/grafana/pyroscope/lidia v0.0.2-0.20251216080959-a49b562cd2fc h1:aaY+Oax8VpaoyGZlBq3h+XIT/aTHkZPm2Op4IVRLykY=
+github.com/grafana/pyroscope/lidia v0.0.2-0.20251216080959-a49b562cd2fc/go.mod h1:4AxmVrn7RJPBStqSw+0erQN2kr+I6MW6LmaawOM8Nlo=
 github.com/grafana/regexp v0.0.0-20221122212121-6b5c0a4cb7fd h1:PpuIBO5P3e9hpqBD0O/HjhShYuM6XE0i/lbE6J94kww=
 github.com/grafana/regexp v0.0.0-20221122212121-6b5c0a4cb7fd/go.mod h1:M5qHK+eWfAv8VR/265dIuEpL3fNfeC21tXXp9itM24A=
 github.com/hashicorp/go-version v1.8.0 h1:KAkNb1HAiZd1ukkxDFGmokVZe1Xy9HG6NUp+bPle2i4=

--- a/pyroscope/symb/irsymcache/cache_test.go
+++ b/pyroscope/symb/irsymcache/cache_test.go
@@ -98,7 +98,7 @@ func TestResolver_ResolveAddress(t *testing.T) {
 					fid:  testFileId(456),
 					addr: 0x9cbb0,
 					expectedRes: SourceInfo{
-						FunctionName: libpf.Intern("__pthread_create_2_1"),
+						FunctionName: libpf.Intern("pthread_create@@GLIBC_2.34"),
 					},
 				},
 			},
@@ -137,7 +137,7 @@ func TestResolver_ResolveAddress(t *testing.T) {
 					fid:  testFileId(4242),
 					addr: 0x9cbb0,
 					expectedRes: SourceInfo{
-						FunctionName: libpf.Intern("__pthread_create_2_1"),
+						FunctionName: libpf.Intern("pthread_create@@GLIBC_2.34"),
 					},
 				},
 			},

--- a/pyroscope/symb/irsymcache/native_frame_symbols_test.go
+++ b/pyroscope/symb/irsymcache/native_frame_symbols_test.go
@@ -31,6 +31,6 @@ func TestNativeFrameSymbols(t *testing.T) {
 			res = si
 		})
 	require.Equal(t, SourceInfo{
-		FunctionName: libpf.Intern("__GI___pthread_cond_timedwait"),
+		FunctionName: libpf.Intern("pthread_cond_timedwait@@GLIBC_2.3.2"),
 	}, res)
 }


### PR DESCRIPTION
This reapplies the change reverts commit  f910fc4db23e6552ed79507de3788f660a9471bc, which was breaking irsa cache tests (not too sure if this is intentionally or a bug.