### PR TITLE
feat: Support negative map_scale_factor for memory optimization

### DIFF
--- a/cli_flags.go
+++ b/cli_flags.go
@@ -42,9 +42,10 @@ var (
 	verboseModeHelp    = "Enable verbose logging and debugging capabilities."
 	tracersHelp        = "Comma-separated list of interpreter tracers to include."
 	mapScaleFactorHelp = fmt.Sprintf("Scaling factor for eBPF map sizes. "+
-		"Every increase by 1 doubles the map size. Increase if you see eBPF map size errors. "+
-		"Default is %d corresponding to 4GB of executable address space, max is %d.",
-		defaultArgMapScaleFactor, config.MaxArgMapScaleFactor)
+		"Every increase by 1 doubles the map size, every decrease by 1 halves it. "+
+		"Increase if you see eBPF map size errors, decrease to reduce memory usage. "+
+		"Default is %d corresponding to 4GB of executable address space, range is [%d, %d].",
+		defaultArgMapScaleFactor, config.MinArgMapScaleFactor, config.MaxArgMapScaleFactor)
 	disableTLSHelp             = "Disable encryption for data in transit."
 	bpfVerifierLogLevelHelp    = "Log level of the eBPF verifier output (0,1,2). Default is 0."
 	versionHelp                = "Show version."
@@ -95,7 +96,7 @@ func parseArgs() (*controller.Config, error) {
 
 	fs.BoolVar(&args.DisableTLS, "disable-tls", false, disableTLSHelp)
 
-	fs.UintVar(&args.MapScaleFactor, "map-scale-factor",
+	fs.IntVar(&args.MapScaleFactor, "map-scale-factor",
 		defaultArgMapScaleFactor, mapScaleFactorHelp)
 
 	fs.DurationVar(&args.MonitorInterval, "monitor-interval", defaultArgMonitorInterval,

--- a/collector/config/config.go
+++ b/collector/config/config.go
@@ -15,6 +15,9 @@ import (
 const (
 	// 1TB of executable address space
 	MaxArgMapScaleFactor = 8
+	// Minimum scale factor to reduce memory usage
+	// -3 means 1/8th of the default map sizes
+	MinArgMapScaleFactor = -3
 )
 
 // Config is the configuration for the collector.
@@ -33,7 +36,7 @@ type Config struct {
 	IncludeEnvVars         string        `mapstructure:"include_env_vars"`
 	ProbeLinks             []string      `mapstructure:"probe_links"`
 	LoadProbe              bool          `mapstructure:"load_probe"`
-	MapScaleFactor         uint          `mapstructure:"map_scale_factor"`
+	MapScaleFactor         int           `mapstructure:"map_scale_factor"`
 	BPFVerifierLogLevel    uint          `mapstructure:"bpf_verifier_log_level"`
 	NoKernelVersionCheck   bool          `mapstructure:"no_kernel_version_check"`
 	MaxGRPCRetries         uint32        `mapstructure:"max_grpc_retries"`
@@ -47,10 +50,10 @@ func (cfg *Config) Validate() error {
 		return fmt.Errorf("invalid sampling frequency: %d", cfg.SamplesPerSecond)
 	}
 
-	if cfg.MapScaleFactor > MaxArgMapScaleFactor {
+	if cfg.MapScaleFactor > MaxArgMapScaleFactor || cfg.MapScaleFactor < MinArgMapScaleFactor {
 		return fmt.Errorf(
-			"eBPF map scaling factor %d exceeds limit (max: %d)",
-			cfg.MapScaleFactor, MaxArgMapScaleFactor,
+			"eBPF map scaling factor %d out of range (min: %d, max: %d)",
+			cfg.MapScaleFactor, MinArgMapScaleFactor, MaxArgMapScaleFactor,
 		)
 	}
 

--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -79,7 +79,7 @@ func (c *Controller) Start(ctx context.Context) error {
 		FilterErrorFrames:      !c.config.SendErrorFrames,
 		FilterIdleFrames:       !c.config.SendIdleFrames,
 		SamplesPerSecond:       c.config.SamplesPerSecond,
-		MapScaleFactor:         int(c.config.MapScaleFactor),
+		MapScaleFactor:         c.config.MapScaleFactor,
 		KernelVersionCheck:     !c.config.NoKernelVersionCheck,
 		VerboseMode:            c.config.VerboseMode,
 		BPFVerifierLogLevel:    uint32(c.config.BPFVerifierLogLevel),

--- a/pyroscope/internalshim/controller/cli_flags.go
+++ b/pyroscope/internalshim/controller/cli_flags.go
@@ -43,9 +43,10 @@ var (
 	verboseModeHelp    = "Enable verbose logging and debugging capabilities."
 	tracersHelp        = "Comma-separated list of interpreter tracers to include."
 	mapScaleFactorHelp = fmt.Sprintf("Scaling factor for eBPF map sizes. "+
-		"Every increase by 1 doubles the map size. Increase if you see eBPF map size errors. "+
-		"Default is %d corresponding to 4GB of executable address space, max is %d.",
-		defaultArgMapScaleFactor, config.MaxArgMapScaleFactor)
+		"Every increase by 1 doubles the map size, every decrease by 1 halves it. "+
+		"Increase if you see eBPF map size errors, decrease to reduce memory usage. "+
+		"Default is %d corresponding to 4GB of executable address space, range is [%d, %d].",
+		defaultArgMapScaleFactor, config.MinArgMapScaleFactor, config.MaxArgMapScaleFactor)
 	disableTLSHelp             = "Disable encryption for data in transit."
 	bpfVerifierLogLevelHelp    = "Log level of the eBPF verifier output (0,1,2). Default is 0."
 	versionHelp                = "Show version."
@@ -95,7 +96,7 @@ func ParseArgs() (*controller.Config, error) {
 
 	fs.BoolVar(&args.DisableTLS, "disable-tls", false, disableTLSHelp)
 
-	fs.UintVar(&args.MapScaleFactor, "map-scale-factor",
+	fs.IntVar(&args.MapScaleFactor, "map-scale-factor",
 		defaultArgMapScaleFactor, mapScaleFactorHelp)
 
 	fs.DurationVar(&args.MonitorInterval, "monitor-interval", defaultArgMonitorInterval,


### PR DESCRIPTION
## Summary

To fix https://github.com/grafana/alloy/issues/5442

Allow negative values for `map_scale_factor` to reduce eBPF map sizes and memory usage in memory-constrained environments.

## Problem

The eBPF profiler allocates kernel memory for maps sized for 4GB of executable address space by default. This results in ~96MB of kernel memory usage per instance, which is excessive for:

- DaemonSet deployments with many instances
- Memory-constrained environments (< 2GB RAM)
- Workloads with smaller executable address spaces

Currently, `map_scale_factor` only accepts values 0-8 (uint), so users cannot reduce memory below the default.

## Solution

Change `MapScaleFactor` from `uint` to `int` and allow values from -3 to 8:

| Value | Map size | Memory impact |
|-------|----------|---------------|
| `-3` | 1/8 default | ~85MB saved |
| `-2` | 1/4 default | ~70MB saved |
| `-1` | 1/2 default | ~45MB saved |
| `0` | Default | Baseline |
| `1-8` | 2x-256x | Increased capacity |

## Changes

- `collector/config/config.go`: Add `MinArgMapScaleFactor = -3`, change `MapScaleFactor` type to `int`
- `cli_flags.go`: Change `UintVar` to `IntVar`, update help text
- `internal/controller/controller.go`: Remove unnecessary type cast
- `pyroscope/internalshim/controller/cli_flags.go`: Same changes as cli_flags.go

## Test results

Deployed to Kubernetes cluster with Grafana Alloy:

| Configuration | Memory usage |
|--------------|--------------|
| Default (map_scale_factor=0) | ~210 MiB |
| map_scale_factor=-3 | ~130 MiB |
| **Reduction** | **~37%** |

## Backward compatibility

- Default value remains `0` (no change for existing users)
- Positive values work the same as before
- Only adds new capability for negative values