### PR TITLE
fix(irsymcache): close memory-mapped tables on LRU eviction

### DIFF
--- a/pyroscope/symb/irsymcache/cache.go
+++ b/pyroscope/symb/irsymcache/cache.go
@@ -115,6 +115,14 @@ func NewFSCache(impl TableFactory, opt Options) (*Resolver, error) {
 		if marker == erroredMarker {
 			return
 		}
+		// Close and remove the memory-mapped table to prevent memory leak
+		res.mutex.Lock()
+		if table, ok := res.tables[id]; ok {
+			table.Close()
+			delete(res.tables, id)
+		}
+		res.mutex.Unlock()
+
 		filePath := res.tableFilePath(id)
 		log.Debugf("symbcache evicting: file=%s", filePath)
 		if err = os.Remove(filePath); err != nil {


### PR DESCRIPTION
## Summary

Fix memory leak where lidia symbol tables (memory-mapped files) are never closed when evicted from the LRU cache, causing unbounded file memory growth.

## Problem

The `irsymcache.Resolver` maintains two data structures:

1. `cache` - LRU cache mapping FileID to cached marker
2. `tables` - Map of FileID to memory-mapped lidia Table

When entries are evicted from the LRU cache, the `SetOnEvict` callback only removes the cache file from disk but **never closes the memory-mapped table**:

```go
// Before: Only removes file, table stays in memory
cache.SetOnEvict(func(id libpf.FileID, marker cachedMarker) {
    if marker == erroredMarker {
        return
    }
    filePath := res.tableFilePath(id)
    if err = os.Remove(filePath); err != nil {
        log.Errorf("symbcache eviction error: %v", err)
    }
})
```

This causes:
- **~115MB of file memory growth** that accumulates over time
- Memory-mapped files remain open indefinitely
- No upper bound on memory usage for symbol tables

## Solution

Close the memory-mapped table and remove from `tables` map before deleting the file:

```go
// After: Close table before removing file
cache.SetOnEvict(func(id libpf.FileID, marker cachedMarker) {
    if marker == erroredMarker {
        return
    }
    // Close and remove the memory-mapped table to prevent memory leak
    res.mutex.Lock()
    if table, ok := res.tables[id]; ok {
        table.Close()
        delete(res.tables, id)
    }
    res.mutex.Unlock()

    filePath := res.tableFilePath(id)
    if err = os.Remove(filePath); err != nil {
        log.Errorf("symbcache eviction error: %v", err)
    }
})
```

## Test results

Deployed to Kubernetes cluster:

| Metric | Before | After |
|--------|--------|-------|
| File memory | ~135 MiB (growing) | ~20 MiB (stable) |

## Note

This PR is based on commit 6d4ae03 (before the pyroscope-specific code was moved). If the irsymcache code has been moved to Alloy, this fix should be applied there instead.

## Related

- Issue: https://github.com/grafana/alloy/issues/5442
- Related PR: https://github.com/grafana/opentelemetry-ebpf-profiler/pull/44