### PR TITLE
fix: Targets without container_id should check the policy

### DIFF
--- a/processmanager/processinfo.go
+++ b/processmanager/processinfo.go
@@ -677,7 +677,8 @@ func (pm *ProcessManager) profilingEnabled(pr process.Process) bool {
 
 	containerID, err := process.ExtractContainerIDCached(pr.PID())
 	if err != nil {
-		return false
+		containerID = ""
+		log.Debugf("Could not detect containerID for pid %d: %s", pr, err.Error())
 	}
 	enabled := pm.policy.ProfilingEnabled(pr, containerID)
 	if enabled {


### PR DESCRIPTION
If the profiler is used without container IDs in the cgroup, it won't work as we bail out early, when an error is returned.