### PR TITLE
Add metrics for all silent sample/trace drop paths (eBPF + Go)

### DIFF
--- a/metrics/ids.go
+++ b/metrics/ids.go
@@ -647,6 +647,21 @@ const (
 	// Number of failed attempts to read a CME by exceeding max EP checks
 	IDUnwindRubyErrCmeMaxEp = 285
 
+	// Number of traces dropped due to unexpected origin in loadBpfTrace
+	IDTraceUnwindUnexpectedOrigin = 286
+
+	// Number of traces dropped due to unexpected errors in loadBpfTrace
+	IDTraceUnwindOtherError = 287
+
+	// Number of failures to read kernel stack frames
+	IDKernelFrameReadError = 288
+
+	// Number of error frames dropped by error frame filtering
+	IDErrorFramesFiltered = 289
+
+	// Number of trace events that failed to be reported
+	IDTraceEventReportError = 290
+
 	// max number of ID values, keep this as *last entry*
-	IDMax = 286
+	IDMax = 291
 )

--- a/metrics/ids.go
+++ b/metrics/ids.go
@@ -662,6 +662,21 @@ const (
 	// Number of trace events that failed to be reported
 	IDTraceEventReportError = 290
 
+	// Number of traces dropped by TEMPORARY HACK: single error frame when filter_error_frames enabled
+	IDBpfTraceSingleErrorDrop = 291
+
+	// Number of tail call failures in eBPF that silently drop a sample mid-unwind
+	IDBpfTailCallFailure = 292
+
+	// Number of traces dropped because PID information not yet loaded in eBPF maps
+	IDBpfPidUnknownDrop = 293
+
+	// Number of traces dropped in go_labels eBPF program due to offsets lookup failure
+	IDBpfGoLabelsDrop = 294
+
+	// Number of profile exports that failed causing all samples in that batch to be lost
+	IDProfileExportError = 295
+
 	// max number of ID values, keep this as *last entry*
-	IDMax = 291
+	IDMax = 296
 )

--- a/metrics/metrics.json
+++ b/metrics/metrics.json
@@ -2098,5 +2098,40 @@
     "name": "TraceEventReportError",
     "field": "agent.trace.errors.report_event",
     "id": 290
+  },
+  {
+    "description": "Number of traces dropped by TEMPORARY HACK: single error frame when filter_error_frames enabled",
+    "type": "counter",
+    "name": "BpfTraceSingleErrorDrop",
+    "field": "bpf.trace.drops.single_error_frame",
+    "id": 291
+  },
+  {
+    "description": "Number of tail call failures in eBPF that silently drop a sample mid-unwind",
+    "type": "counter",
+    "name": "BpfTailCallFailure",
+    "field": "bpf.trace.drops.tail_call_failure",
+    "id": 292
+  },
+  {
+    "description": "Number of traces dropped because PID information not yet loaded in eBPF maps",
+    "type": "counter",
+    "name": "BpfPidUnknownDrop",
+    "field": "bpf.trace.drops.pid_unknown",
+    "id": 293
+  },
+  {
+    "description": "Number of traces dropped in go_labels eBPF program due to offsets lookup failure",
+    "type": "counter",
+    "name": "BpfGoLabelsDrop",
+    "field": "bpf.trace.drops.go_labels",
+    "id": 294
+  },
+  {
+    "description": "Number of profile exports that failed causing all samples in that batch to be lost",
+    "type": "counter",
+    "name": "ProfileExportError",
+    "field": "agent.profile.errors.export",
+    "id": 295
   }
 ]

--- a/metrics/metrics.json
+++ b/metrics/metrics.json
@@ -2063,5 +2063,40 @@
     "name": "UnwindRubyErrCmeMaxEp",
     "field": "bpf.ruby.errors.read_cme_max_ep",
     "id": 285
+  },
+  {
+    "description": "Number of traces dropped due to unexpected origin in loadBpfTrace",
+    "type": "counter",
+    "name": "TraceUnwindUnexpectedOrigin",
+    "field": "agent.trace.errors.unexpected_origin",
+    "id": 286
+  },
+  {
+    "description": "Number of traces dropped due to unexpected errors in loadBpfTrace",
+    "type": "counter",
+    "name": "TraceUnwindOtherError",
+    "field": "agent.trace.errors.unwind_other",
+    "id": 287
+  },
+  {
+    "description": "Number of failures to read kernel stack frames",
+    "type": "counter",
+    "name": "KernelFrameReadError",
+    "field": "agent.trace.errors.kernel_frame_read",
+    "id": 288
+  },
+  {
+    "description": "Number of error frames dropped by error frame filtering",
+    "type": "counter",
+    "name": "ErrorFramesFiltered",
+    "field": "agent.trace.filtered_error_frames",
+    "id": 289
+  },
+  {
+    "description": "Number of trace events that failed to be reported",
+    "type": "counter",
+    "name": "TraceEventReportError",
+    "field": "agent.trace.errors.report_event",
+    "id": 290
   }
 ]

--- a/processmanager/manager.go
+++ b/processmanager/manager.go
@@ -346,6 +346,8 @@ func (pm *ProcessManager) HandleTrace(bpfTrace *libpf.EbpfTrace) {
 					Type:            frame.Type().Error(),
 					AddressOrLineno: libpf.AddressOrLineno(frame.Data()),
 				})
+			} else {
+				metrics.Add(metrics.IDErrorFramesFiltered, 1)
 			}
 			continue
 		}
@@ -387,6 +389,7 @@ func (pm *ProcessManager) HandleTrace(bpfTrace *libpf.EbpfTrace) {
 	meta.APMServiceName = pm.maybeNotifyAPMAgent(bpfTrace, trace.Hash, 1)
 
 	if err := pm.traceReporter.ReportTraceEvent(trace, meta); err != nil {
+		metrics.Add(metrics.IDTraceEventReportError, 1)
 		log.Errorf("Failed to report trace event: %v", err)
 	}
 }

--- a/reporter/collector_reporter.go
+++ b/reporter/collector_reporter.go
@@ -11,6 +11,7 @@ import (
 	"go.opentelemetry.io/ebpf-profiler/internal/log"
 
 	"go.opentelemetry.io/ebpf-profiler/libpf"
+	"go.opentelemetry.io/ebpf-profiler/metrics"
 	"go.opentelemetry.io/ebpf-profiler/libpf/xsync"
 	"go.opentelemetry.io/ebpf-profiler/reporter/internal/pdata"
 	"go.opentelemetry.io/ebpf-profiler/reporter/samples"
@@ -93,6 +94,7 @@ func (r *CollectorReporter) reportProfile(ctx context.Context) error {
 	profiles, err := r.pdata.Generate(reportedEvents, r.name, r.version,
 		collectionStartTime, collectionEndTime)
 	if err != nil {
+		metrics.Add(metrics.IDProfileExportError, 1)
 		log.Errorf("pdata: %v", err)
 		return nil
 	}

--- a/support/ebpf/beam_tracer.ebpf.c
+++ b/support/ebpf/beam_tracer.ebpf.c
@@ -238,6 +238,7 @@ exit:
   state->unwind_error = error;
   tail_call(ctx, unwinder);
   DEBUG_PRINT("beam: tail call for next frame unwinder (%d) failed", unwinder);
+  increment_metric(metricID_BpfTailCallFailure);
   return -1;
 }
 

--- a/support/ebpf/dotnet_tracer.ebpf.c
+++ b/support/ebpf/dotnet_tracer.ebpf.c
@@ -453,6 +453,7 @@ exit:
   record->state.unwind_error = error;
   tail_call(ctx, unwinder);
   DEBUG_PRINT("dotnet: tail call for next frame unwinder (%d) failed", unwinder);
+  increment_metric(metricID_BpfTailCallFailure);
   return -1;
 }
 

--- a/support/ebpf/go_labels.ebpf.c
+++ b/support/ebpf/go_labels.ebpf.c
@@ -182,6 +182,7 @@ static EBPF_INLINE int go_labels(struct pt_regs *ctx)
   GoLabelsOffsets *offsets = bpf_map_lookup_elem(&go_labels_procs, &pid);
   if (!offsets) {
     DEBUG_PRINT("cl: no offsets, %d not recognized as a go binary", pid);
+    increment_metric(metricID_BpfGoLabelsDrop);
     return -1;
   }
   DEBUG_PRINT(

--- a/support/ebpf/hotspot_tracer.ebpf.c
+++ b/support/ebpf/hotspot_tracer.ebpf.c
@@ -959,6 +959,7 @@ exit:
   record->state.unwind_error = error;
   tail_call(ctx, unwinder);
   DEBUG_PRINT("jvm: tail call for next frame unwinder (%d) failed", unwinder);
+  increment_metric(metricID_BpfTailCallFailure);
   return -1;
 }
 MULTI_USE_FUNC(unwind_hotspot)

--- a/support/ebpf/interpreter_dispatcher.ebpf.c
+++ b/support/ebpf/interpreter_dispatcher.ebpf.c
@@ -289,6 +289,7 @@ static EBPF_INLINE int unwind_stop(struct pt_regs *ctx)
   // this is trivial.
   if (trace->frame_data_len == 1 && trace->kernel_stack_id < 0 && state->unwind_error) {
     if (filter_error_frames) {
+      increment_metric(metricID_BpfTraceSingleErrorDrop);
       return 0;
     }
   }

--- a/support/ebpf/native_stack_trace.ebpf.c
+++ b/support/ebpf/native_stack_trace.ebpf.c
@@ -604,6 +604,7 @@ static EBPF_INLINE int unwind_native(struct pt_regs *ctx)
   record->state.unwind_error = error;
   tail_call(ctx, unwinder);
   DEBUG_PRINT("bpf_tail call failed for %d in unwind_native", unwinder);
+  increment_metric(metricID_BpfTailCallFailure);
   return -1;
 }
 

--- a/support/ebpf/perl_tracer.ebpf.c
+++ b/support/ebpf/perl_tracer.ebpf.c
@@ -439,6 +439,7 @@ static EBPF_INLINE int unwind_perl(struct pt_regs *ctx)
 
 exit:
   tail_call(ctx, unwinder);
+  increment_metric(metricID_BpfTailCallFailure);
   return -1;
 }
 MULTI_USE_FUNC(unwind_perl)

--- a/support/ebpf/php_tracer.ebpf.c
+++ b/support/ebpf/php_tracer.ebpf.c
@@ -262,6 +262,7 @@ static EBPF_INLINE int unwind_php(struct pt_regs *ctx)
 
 exit:
   tail_call(ctx, unwinder);
+  increment_metric(metricID_BpfTailCallFailure);
   return -1;
 }
 MULTI_USE_FUNC(unwind_php)

--- a/support/ebpf/python_tracer.ebpf.c
+++ b/support/ebpf/python_tracer.ebpf.c
@@ -333,6 +333,7 @@ static EBPF_INLINE int unwind_python(struct pt_regs *ctx)
 exit:
   record->state.unwind_error = error;
   tail_call(ctx, unwinder);
+  increment_metric(metricID_BpfTailCallFailure);
   return -1;
 }
 MULTI_USE_FUNC(unwind_python)

--- a/support/ebpf/ruby_tracer.ebpf.c
+++ b/support/ebpf/ruby_tracer.ebpf.c
@@ -560,6 +560,7 @@ static EBPF_INLINE int unwind_ruby(struct pt_regs *ctx)
 exit:
   record->state.unwind_error = error;
   tail_call(ctx, unwinder);
+  increment_metric(metricID_BpfTailCallFailure);
   return -1;
 }
 MULTI_USE_FUNC(unwind_ruby)

--- a/support/ebpf/tracemgmt.h
+++ b/support/ebpf/tracemgmt.h
@@ -753,6 +753,7 @@ static inline EBPF_INLINE int collect_trace(
     if (report_pid(ctx, pid_tgid, RATELIMIT_ACTION_DEFAULT)) {
       increment_metric(metricID_NumProcNew);
     }
+    increment_metric(metricID_BpfPidUnknownDrop);
     return 0;
   }
   error = get_next_unwinder_after_native_frame(record, &unwinder);
@@ -761,6 +762,7 @@ exit:
   record->state.unwind_error = error;
   tail_call(ctx, unwinder);
   DEBUG_PRINT("bpf_tail call failed for %d in native_tracer_entry", unwinder);
+  increment_metric(metricID_BpfTailCallFailure);
   return -1;
 }
 

--- a/support/ebpf/types.h
+++ b/support/ebpf/types.h
@@ -325,6 +325,18 @@ enum {
   // number of failed attempts to read a CME by exceeding max EP checks
   metricID_UnwindRubyErrCmeMaxEp,
 
+  // number of traces dropped by the single-error-frame filter (TEMPORARY HACK)
+  metricID_BpfTraceSingleErrorDrop,
+
+  // number of tail call failures causing sample drops
+  metricID_BpfTailCallFailure,
+
+  // number of traces dropped because PID info not yet loaded
+  metricID_BpfPidUnknownDrop,
+
+  // number of traces dropped in go_labels (record/offsets lookup failure)
+  metricID_BpfGoLabelsDrop,
+
   //
   // Metric IDs above are for counters (cumulative values)
   //

--- a/support/ebpf/v8_tracer.ebpf.c
+++ b/support/ebpf/v8_tracer.ebpf.c
@@ -350,6 +350,7 @@ exit:
   record->state.unwind_error = error;
   tail_call(ctx, unwinder);
   DEBUG_PRINT("v8: tail call for next frame unwinder (%d) failed", unwinder);
+  increment_metric(metricID_BpfTailCallFailure);
   return -1;
 }
 MULTI_USE_FUNC(unwind_v8)

--- a/support/types.go
+++ b/support/types.go
@@ -489,4 +489,8 @@ var MetricsTranslation = []metrics.MetricID{
 	0x65: metrics.IDUnwindRubyErrReadSvar,
 	0x66: metrics.IDUnwindRubyErrReadRbasicFlags,
 	0x67: metrics.IDUnwindRubyErrCmeMaxEp,
+	0x68: metrics.IDBpfTraceSingleErrorDrop,
+	0x69: metrics.IDBpfTailCallFailure,
+	0x6a: metrics.IDBpfPidUnknownDrop,
+	0x6b: metrics.IDBpfGoLabelsDrop,
 }

--- a/tracer/events.go
+++ b/tracer/events.go
@@ -223,6 +223,7 @@ func (t *Tracer) startTraceEventMonitor(ctx context.Context,
 				case err == nil:
 					// Fast path for no error.
 				case errors.Is(err, errOriginUnexpected):
+					metrics.Add(metrics.IDTraceUnwindUnexpectedOrigin, 1)
 					log.Warnf("skip trace handling: %v", err)
 					continue
 				case errors.Is(err, errRecordTooSmall), errors.Is(err, errRecordUnexpectedSize):
@@ -230,6 +231,7 @@ func (t *Tracer) startTraceEventMonitor(ctx context.Context,
 					// TODO: trigger a graceful shutdown
 					return
 				default:
+					metrics.Add(metrics.IDTraceUnwindOtherError, 1)
 					log.Warnf("unexpected error handling trace: %v", err)
 					continue
 				}

--- a/tracer/tracer.go
+++ b/tracer/tracer.go
@@ -1049,6 +1049,7 @@ func (t *Tracer) loadBpfTrace(raw []byte, cpu int) (*libpf.EbpfTrace, error) {
 		var err error
 		trace.KernelFrames, err = t.readKernelFrames(ptr.Kernel_stack_id, trace.KernelFrames)
 		if err != nil {
+			metrics.Add(metrics.IDKernelFrameReadError, 1)
 			log.Errorf("Failed to get kernel stack frames: %v", err)
 		}
 	}


### PR DESCRIPTION
## Summary

The eBPF profiler has numerous code paths — both in eBPF C code and Go userspace code — where samples, traces, or frames are silently dropped with no metric incremented. This makes data loss invisible to monitoring and extremely hard to debug.

This PR adds **10 new counter metrics** covering every identified silent drop point across 20 files.

## Motivation

While investigating silent fiber thread sample drops, we discovered the root cause was a "TEMPORARY HACK" in `interpreter_dispatcher.ebpf.c` that silently discards single-error-frame traces when `filter_error_frames` is enabled. There was no metric for this, making the issue invisible. This PR ensures that **every** sample drop path now increments a counter, so operators can detect and alert on data loss.

## Changes

### eBPF-side (4 new metrics, 13 instrumentation sites)

| Metric | Description |
|--------|-------------|
| `BpfTraceSingleErrorDrop` | TEMPORARY HACK: traces with a single error frame dropped when `filter_error_frames` is on — **root cause of silent fiber thread sample loss** |
| `BpfTailCallFailure` | Tail call failures in any of the 10 unwinder programs (native, python, hotspot, php, ruby, perl, v8, dotnet, beam, collect_trace) |
| `BpfPidUnknownDrop` | Traces dropped in `collect_trace()` because PID info not yet loaded in eBPF maps |
| `BpfGoLabelsDrop` | Traces dropped in `go_labels` when offsets map lookup fails |

### Go-side (6 new metrics)

| Metric | Description |
|--------|-------------|
| `TraceUnwindUnexpectedOrigin` | Traces dropped due to unexpected origin in `loadBpfTrace` |
| `TraceUnwindOtherError` | Traces dropped due to misc errors in `loadBpfTrace` |
| `KernelFrameReadError` | Kernel stack frames lost when stackmap lookup fails |
| `ErrorFramesFiltered` | Error frames dropped when `filterErrorFrames` is enabled |
| `TraceEventReportError` | Trace events lost when `ReportTraceEvent` fails |
| `ProfileExportError` | Profile export failures where an entire batch of samples is lost |

### Files modified

- `support/ebpf/types.h` — 4 new `metricID_` enum values
- `support/ebpf/interpreter_dispatcher.ebpf.c` — TEMPORARY HACK drop metric
- `support/ebpf/tracemgmt.h` — `collect_trace()` PID unknown + tail call failure
- 9 interpreter unwinder files — tail call failure metrics
- `support/ebpf/go_labels.ebpf.c` — offsets lookup failure metric
- `support/types.go` — MetricsTranslation entries for eBPF→Go mapping
- `metrics/metrics.json` + `metrics/ids.go` — 10 new metric definitions (IDs 286–295)
- `tracer/events.go`, `tracer/tracer.go` — Go trace processing drop metrics
- `processmanager/manager.go` — error frame filtering + report failure metrics
- `reporter/collector_reporter.go` — profile export failure metric

## Test plan

- [x] `go generate ./metrics/...` regenerates `ids.go` correctly (IDMax = 296)
- [x] `go build ./...` compiles without errors
- [x] `go test ./metrics/... ./reporter/... ./support/...` passes
- [ ] eBPF code needs `make -C support/ebpf` rebuild (not done in CI-less env)
- [ ] Verify new metrics appear in OTel output when sample drops occur

🤖 Generated with [Claude Code](https://claude.com/claude-code)