### PR TITLE
fix: set GOTOOLCHAIN=auto in denovate CI job

### DIFF
--- a/.github/workflows/denovate-opentelemetry-from-alloy.yml
+++ b/.github/workflows/denovate-opentelemetry-from-alloy.yml
@@ -14,6 +14,8 @@ permissions:
 jobs:
   denovate:
     runs-on: ubuntu-24.04
+    env:
+      GOTOOLCHAIN: auto
     permissions:
       contents: write
       pull-requests: write


### PR DESCRIPTION
## Summary

The denovate CI job fails when Alloy requires a newer Go version than what's specified in `go.mod`.

- **Error**: `github.com/grafana/alloy@v1.14.1-0.20260325155204-d41dab4ce3b5 requires go >= 1.25.8 (running go 1.25.0; GOTOOLCHAIN=local)`
- **Root cause**: The job installs Go from `go.mod` (1.25.0) and defaults to `GOTOOLCHAIN=local`, which prevents auto-downloading a newer toolchain
- **Fix**: Set `GOTOOLCHAIN=auto` at the job level so Go automatically downloads the required toolchain when a module needs it

This is more robust than bumping the Go version in `go.mod` (affects the entire project) or pinning a specific newer version in `setup-go` (needs manual updates whenever Alloy bumps its Go requirement).

🤖 Generated with [Claude Code](https://claude.com/claude-code)